### PR TITLE
#68 add format types for responses

### DIFF
--- a/EosLib/format/base_format.py
+++ b/EosLib/format/base_format.py
@@ -37,3 +37,6 @@ class BaseFormat(ABC):
     @abstractmethod
     def decode(cls, data: bytes) -> Self:
         raise NotImplementedError
+
+    def to_string(self) -> str:
+        return self.__class__.__name__

--- a/EosLib/format/definitions.py
+++ b/EosLib/format/definitions.py
@@ -1,18 +1,24 @@
 from enum import unique, IntEnum
 
 
-@unique
 class Type(IntEnum):
     NO_TYPE = 0
     TELEMETRY = 1
     WARNING = 2
     DATA = 3
     POSITION = 4
-    COMMAND = 5
-    TELEMETRY_DATA = 7
-    EMPTY = 8
+    TELEMETRY_DATA = 5
+    EMPTY = 6
     RESPONSE_START = 32
-    PING_RESPONSE = 33
-    CUTDOWN_RESPONSE = 34
-    RESPONSE_END = 35
+    RESPONSE_1 = 33
+    RESPONSE_2 = 34
+    RESPONSE_3 = 35
+    RESPONSE_4 = 36
+    RESPONSE_END = 37
+    COMMAND_START = 32
+    COMMAND_1 = 40
+    COMMAND_2 = 41
+    COMMAND_3 = 42
+    COMMAND_4 = 43
+    COMMAND_END = 44
     ERROR = 255

--- a/EosLib/format/definitions.py
+++ b/EosLib/format/definitions.py
@@ -9,7 +9,10 @@ class Type(IntEnum):
     DATA = 3
     POSITION = 4
     COMMAND = 5
-    RESPONSE = 6
     TELEMETRY_DATA = 7
     EMPTY = 8
+    RESPONSE_START = 32
+    PING_RESPONSE = 33
+    CUTDOWN_RESPONSE = 34
+    RESPONSE_END = 35
     ERROR = 255

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 setup(name='EosLib',
-      version='4.0.0',
+      version='4.0.1',
       description='Library of shared code between EosPayload and EosGround',
       author='Lightning From The Edge of Space',
       author_email='thomasmholder@gmail.com',


### PR DESCRIPTION
- Created the format types for the responses of the ping and cutdown commands
- Implemented it with two enum values of "RESPONSE_START" and "RESPONSE_END", with all valid response types in between. If many more responses get added in the future, it will be easier to check if a packet received is a response by checking if it is between "RESPONSE_START" and "RESPONSE_END", rather than having a very long OR statement.
- Made the value of the responses start at 32, so that we leave space for other types below it if necessary.
- New version number: 4.0.1