### PR TITLE
Cast packet enum types 

### DIFF
--- a/EosLib/packet/packet.py
+++ b/EosLib/packet/packet.py
@@ -55,10 +55,10 @@ class Packet:
             output_string += "No data header\n"
         else:
             output_string += f"Data Header:\n" \
-                             f"\tSender: {Device(self.data_header.sender)}\n" \
-                             f"\tData type: {Type(self.data_header.data_type)}\n" \
-                             f"\tPriority: {Priority(self.data_header.priority)}\n" \
-                             f"\tDestination: {Device(self.data_header.destination)}\n" \
+                             f"\tSender: {Device(self.data_header.sender).name}\n" \
+                             f"\tData type: {Type(self.data_header.data_type).name}\n" \
+                             f"\tPriority: {Priority(self.data_header.priority).name}\n" \
+                             f"\tDestination: {Device(self.data_header.destination).name}\n" \
                              f"\tGenerate Time: {self.data_header.generate_time}\n"
 
         if self.body is None:

--- a/EosLib/packet/packet.py
+++ b/EosLib/packet/packet.py
@@ -58,7 +58,7 @@ class Packet:
                              f"\tSender: {Device(self.data_header.sender).name}\n" \
                              f"\tData type: {Type(self.data_header.data_type).name}\n" \
                              f"\tPriority: {Priority(self.data_header.priority).name}\n" \
-                             f"\tDestination: {self.data_header.destination.name}\n" \
+                             f"\tDestination: {Device(self.data_header.destination).name}\n" \
                              f"\tGenerate Time: {self.data_header.generate_time}\n"
 
         if self.body is None:

--- a/EosLib/packet/packet.py
+++ b/EosLib/packet/packet.py
@@ -55,10 +55,10 @@ class Packet:
             output_string += "No data header\n"
         else:
             output_string += f"Data Header:\n" \
-                             f"\tSender: {Device(self.data_header.sender).name}\n" \
-                             f"\tData type: {Type(self.data_header.data_type).name}\n" \
-                             f"\tPriority: {Priority(self.data_header.priority).name}\n" \
-                             f"\tDestination: {Device(self.data_header.destination).name}\n" \
+                             f"\tSender: {Device(self.data_header.sender)}\n" \
+                             f"\tData type: {Type(self.data_header.data_type)}\n" \
+                             f"\tPriority: {Priority(self.data_header.priority)}\n" \
+                             f"\tDestination: {Device(self.data_header.destination)}\n" \
                              f"\tGenerate Time: {self.data_header.generate_time}\n"
 
         if self.body is None:

--- a/EosLib/packet/packet.py
+++ b/EosLib/packet/packet.py
@@ -1,7 +1,9 @@
 import struct
 
+from EosLib.device import Device
 import EosLib.format.decode_factory
 from EosLib.format.base_format import BaseFormat
+from EosLib.format.definitions import Type
 
 from EosLib.packet.transmit_header import TransmitHeader
 from EosLib.packet.data_header import DataHeader
@@ -53,9 +55,9 @@ class Packet:
             output_string += "No data header\n"
         else:
             output_string += f"Data Header:\n" \
-                             f"\tSender: {self.data_header.sender.name}\n" \
-                             f"\tData type: {self.data_header.data_type.name}\n" \
-                             f"\tPriority: {self.data_header.priority.name}\n" \
+                             f"\tSender: {Device(self.data_header.sender).name}\n" \
+                             f"\tData type: {Type(self.data_header.data_type).name}\n" \
+                             f"\tPriority: {Priority(self.data_header.priority).name}\n" \
                              f"\tDestination: {self.data_header.destination.name}\n" \
                              f"\tGenerate Time: {self.data_header.generate_time}\n"
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 setup(name='EosLib',
-      version='4.3.4',
+      version='4.3.5',
       description='Library of shared code between EosPayload and EosGround',
       author='Lightning From The Edge of Space',
       author_email='thomasmholder@gmail.com',


### PR DESCRIPTION
In the Packet str() method, cast the enums to their correct types in order to successfully call .name on the values.